### PR TITLE
Add settings tab with configuration storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Emotional Virtual Intelligence - modular prototype.
 
-This application provides a PyQt5 dashboard to experiment with hormone levels and emotional visualization. Hormones are adjusted with sliders and their effect on emotions is displayed in a live radar chart. A simple chat interface stores all messages along with hormone states.
+This application provides a PyQt5 dashboard to experiment with hormone levels and emotional visualization. Hormones are adjusted with sliders and their effect on emotions is displayed in a live radar chart. A simple chat interface stores all messages along with hormone states. A settings tab allows configuration of the LLM API key and the initial context prompt.
 
 Run the GUI:
 

--- a/evi/gui/main_window.py
+++ b/evi/gui/main_window.py
@@ -3,7 +3,9 @@ from PyQt5 import QtWidgets
 from .hormone_widget import HormoneWidget
 from .chat_widget import ChatWidget
 from .emotion_graph import EmotionGraphWidget, EMOTIONS
+from .settings_widget import SettingsWidget
 from ..memory.memory_db import MemoryDB
+from ..settings.settings_db import SettingsDB
 
 
 def hormone_to_emotions(hormones: Dict[str, int]) -> Dict[str, float]:
@@ -39,8 +41,12 @@ class MainWindow(QtWidgets.QWidget):
             'melatonin': 50,
         }
         self.memory = MemoryDB()
+        self.settings = SettingsDB()
 
-        layout = QtWidgets.QHBoxLayout()
+        self.tab_widget = QtWidgets.QTabWidget()
+
+        dashboard = QtWidgets.QWidget()
+        dash_layout = QtWidgets.QHBoxLayout()
 
         self.hormone_widget = HormoneWidget(self.hormones)
         self.chat_widget = ChatWidget(self.hormones, self.memory)
@@ -48,9 +54,17 @@ class MainWindow(QtWidgets.QWidget):
 
         self.hormone_widget.hormones_changed.connect(self._on_hormones_changed)
 
-        layout.addWidget(self.hormone_widget)
-        layout.addWidget(self.emotion_widget)
-        layout.addWidget(self.chat_widget)
+        dash_layout.addWidget(self.hormone_widget)
+        dash_layout.addWidget(self.emotion_widget)
+        dash_layout.addWidget(self.chat_widget)
+        dashboard.setLayout(dash_layout)
+        self.tab_widget.addTab(dashboard, "Dashboard")
+
+        self.settings_widget = SettingsWidget(self.settings)
+        self.tab_widget.addTab(self.settings_widget, "Settings")
+
+        layout = QtWidgets.QVBoxLayout()
+        layout.addWidget(self.tab_widget)
         self.setLayout(layout)
 
     def _on_hormones_changed(self, hormones: Dict[str, int]) -> None:

--- a/evi/gui/settings_widget.py
+++ b/evi/gui/settings_widget.py
@@ -1,0 +1,32 @@
+from PyQt5 import QtWidgets
+from ..settings.settings_db import SettingsDB
+
+
+class SettingsWidget(QtWidgets.QWidget):
+    """Widget to edit application settings."""
+
+    def __init__(self, settings: SettingsDB, parent=None) -> None:
+        super().__init__(parent)
+        self.settings = settings
+
+        layout = QtWidgets.QFormLayout()
+
+        self.api_key_edit = QtWidgets.QLineEdit()
+        self.api_key_edit.setText(self.settings.get("llm_api_key", ""))
+        layout.addRow("LLM API Key:", self.api_key_edit)
+
+        self.context_edit = QtWidgets.QPlainTextEdit()
+        self.context_edit.setPlainText(self.settings.get("context_prompt", ""))
+        layout.addRow("Context Prompt:", self.context_edit)
+
+        self.save_button = QtWidgets.QPushButton("Save")
+        self.save_button.clicked.connect(self._save)
+        layout.addRow(self.save_button)
+
+        layout.addItem(QtWidgets.QSpacerItem(20, 40, QtWidgets.QSizePolicy.Expanding,
+                                             QtWidgets.QSizePolicy.Expanding))
+        self.setLayout(layout)
+
+    def _save(self) -> None:
+        self.settings.set("llm_api_key", self.api_key_edit.text().strip())
+        self.settings.set("context_prompt", self.context_edit.toPlainText().strip())

--- a/evi/settings/settings_db.py
+++ b/evi/settings/settings_db.py
@@ -1,0 +1,31 @@
+import json
+import os
+from typing import Any, Dict
+
+SETTINGS_FILE = "settings.json"
+
+class SettingsDB:
+    """Simple JSON settings storage."""
+    def __init__(self, path: str = SETTINGS_FILE):
+        self.path = path
+        self.data: Dict[str, Any] = {}
+        self._load()
+
+    def _load(self) -> None:
+        if os.path.exists(self.path):
+            try:
+                with open(self.path, 'r') as f:
+                    self.data = json.load(f)
+            except Exception:
+                self.data = {}
+
+    def save(self) -> None:
+        with open(self.path, 'w') as f:
+            json.dump(self.data, f, indent=2)
+
+    def set(self, key: str, value: Any) -> None:
+        self.data[key] = value
+        self.save()
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self.data.get(key, default)


### PR DESCRIPTION
## Summary
- add a JSON-based `SettingsDB` for storing app settings like API keys
- add `SettingsWidget` class and integrate it in the GUI via a new tab
- switch main window to a tabbed layout and include new settings tab
- document settings tab in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685f69091784832c86fc1f5f962a7fa3